### PR TITLE
fix(#39): rc2 Alpha-Gold MVP — offscreen reasons + ingredient thumbnails

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -156,8 +156,8 @@ async function init (): Promise<void> {
     await chrome.offscreen
       .createDocument({
         url: 'offscreen.html',
-        reasons: [chrome.offscreen.Reason.DOM_PARSER],
-        justification: 'Private DOM access to parse HTML'
+        reasons: [chrome.offscreen.Reason.DOM_PARSER, chrome.offscreen.Reason.WORKERS],
+        justification: 'Parse C2PA manifest DOM and run WebAssembly verification in a Web Worker (both forbidden in MV3 service workers)'
       })
       .catch((error) => {
         console.error('Failed to create offscreen document', error)

--- a/src/c2pa.ts
+++ b/src/c2pa.ts
@@ -193,28 +193,37 @@ async function serializeC2paReadResult (result: C2paReadResult): Promise<Extensi
   }
   const c2paManifests: ManifestMap = manifestStore.manifests
   const c2paActiveManifest = manifestStore.activeManifest
-  const manifests: ExtensionC2paManifest[] = Object.entries(c2paManifests).map(([key, value]) => {
-    return {
-      key,
-      title: value.title,
-      format: value.format,
-      claimGenerator: value.claimGenerator,
-      signatureInfo: {
-        issuer: value.signatureInfo?.issuer ?? ''
-      },
-      ingredients: value.ingredients.map(ingredient => {
-        return {
-          title: ingredient.title,
-          format: ingredient.format,
-          instanceId: ingredient.instanceId,
-          thumbnail: {
-            type: ingredient.thumbnail?.contentType ?? '',
-            data: ''
+  const manifests: ExtensionC2paManifest[] = await Promise.all(
+    Object.entries(c2paManifests).map(async ([key, value]) => {
+      const ingredients = await Promise.all(
+        value.ingredients.map(async ingredient => {
+          const thumbType = ingredient.thumbnail?.contentType ?? ''
+          const thumbData =
+            (thumbType.startsWith('image/') && ingredient.thumbnail?.blob != null)
+              ? await blobToDataURL(ingredient.thumbnail.blob)
+              : ''
+          return {
+            title: ingredient.title,
+            format: ingredient.format,
+            instanceId: ingredient.instanceId,
+            thumbnail: {
+              type: thumbType,
+              data: thumbData
+            }
           }
-        }
-      })
-    }
-  }
+        })
+      )
+      return {
+        key,
+        title: value.title,
+        format: value.format,
+        claimGenerator: value.claimGenerator,
+        signatureInfo: {
+          issuer: value.signatureInfo?.issuer ?? ''
+        },
+        ingredients
+      }
+    })
   )
 
   const activeManifestIndex = Object.values(c2paManifests).indexOf(c2paActiveManifest)


### PR DESCRIPTION
## Summary

Surgical rc2 branch for the Alpha-Gold MVP demo gate (issue #39). Cherry-picks ONLY the narrow fixes for Defects 3 and 5 — none of the `feature/scaleway-infrastructure` tree was carried. Built cleanly off `main` at 3637e4b.

Fixes #39 (partial — see Status section below).

## What's in this PR

### Defect 5 — DOM_PARSER + WORKERS offscreen reason  (commit 9dab195)
`src/background.ts`: the offscreen document was being created with only `DOM_PARSER` as its reason. `c2pa.js` internally launches a WebAssembly verification in a Web Worker, which Chrome MV3 rejects without the `WORKERS` reason — producing the "Receiving end does not exist" failure M observed on the right-click validation flow. Both reasons now present; justification string updated.

Verified compiled `dist/chrome/background.js` contains `reasons:[chrome.offscreen.Reason.DOM_PARSER,chrome.offscreen.Reason.WORKERS]`.

### Defect 3 — Ingredient thumbnails render  (commit f79de08)
`src/c2pa.ts`: `serializeC2paReadResult` was hardcoding each ingredient's `thumbnail.data` to an empty string. Switched the manifest serialization to an async `Promise.all` so each ingredient can `await blobToDataURL(ingredient.thumbnail.blob)` when a blob is present and the content type is `image/*`. Falls back to `''` on unsupported types, preserving prior behaviour.

## Status of the other #39 defects

- **Defect 1 (green trust indicator)** — NOT in this PR. The fix requires fresh test fixtures with valid certificate chains + TSA timestamps. The content-archivist subagent running in parallel is the owner of those fixtures; they weren't available in this working tree during the sprint. Q flagging this blocker back to the orchestrator.
- **Defect 2 (warning icon disappears)** — NOT in this PR. Root-cause investigation points to `MediaMonitor.mutationObserver` re-removing and re-adding the MediaRecord on src attribute churn, which wipes the existing `CrIcon` div. That's a deeper rework than a one-commit surgical pass warrants; filing a follow-up so this PR stays tight.
- **Defect 4 (no-C2PA exclamation icon)** — explicitly deferred to v1.1 per the Stimmt session decision. No code touched.

## How to verify

1. Check out `feature/39-rc2-offscreen-reasons`.
2. `bun install && bun run build`.
3. Load `dist/chrome/` unpacked in Chrome. 
4. Right-click a signed image and pick "Inspect Content Credentials" — the validation pin icon should now appear (Defect 5).
5. Open an image with ingredients in the provenance popup — each ingredient should now show its thumbnail (Defect 3).

## Branch note

The branch was originally specified as `rc2/offscreen-reasons` but the repo's `IssueGate.hook.ts` requires an issue number in the branch name. Used the fallback `feature/39-rc2-offscreen-reasons` as pre-authorised by M in the sprint brief.

## Test plan

- [ ] M loads the unpacked `dist/chrome/` extension in Chrome
- [ ] Right-click validation on a signed image produces a pin icon
- [ ] Provenance popup renders ingredient thumbnails
- [ ] No regression on already-working untrusted-error flow
- [ ] Before merge: await fixes for Defects 1 and 2 (separate follow-up work)

**DO NOT MERGE** until M validates the demo and confirms on the voice channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)