### PR TITLE
fix(#45): silence 'Receiving end does not exist' error flood

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -55,7 +55,7 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
     }
     const message = { action: MSG_C2PA_RESULT_FROM_CONTEXT, data: { url, c2paResult, frame: info.frameId } }
     if (tab?.id != null) {
-      void chrome.tabs.sendMessage(tab.id, message)
+      chrome.tabs.sendMessage(tab.id, message).catch(() => { /* tab may not have a content-script listener */ })
     }
   })
 })
@@ -87,13 +87,13 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         // This is a temporary workaround to wait for the content script to be ready.
         // We should have the content script send a message to the background script when it is ready. Then we can remove this timeout.
         setTimeout(() => {
-          void chrome.tabs.sendMessage(id, { action: MSG_REMOTE_INSPECT_URL, data })
+          chrome.tabs.sendMessage(id, { action: MSG_REMOTE_INSPECT_URL, data }).catch(() => { /* content script may not yet be ready */ })
         }, 1000)
       })
   }
 
   if (action === MSG_FORWARD_TO_CONTENT && tabId != null) {
-    void chrome.tabs.sendMessage(tabId, data)
+    chrome.tabs.sendMessage(tabId, data).catch(() => { /* content script may be absent on this tab */ })
   }
 
   if (action === MSG_VALIDATE_URL) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -130,11 +130,16 @@ export function dataURLtoBlob (dataurl: string): Blob | null {
 
 export async function sendMessageToAllTabs (message: MSG_PAYLOAD): Promise<void> {
   const tabs = await chrome.tabs.query({})
-  tabs.filter(tab => tab.id != null).forEach(function (tab) {
-    if (tab.id == null) {
-      return
-    }
-    void chrome.tabs.sendMessage(tab.id, message)
+  // Only http(s) tabs can carry our content scripts. Filter out chrome://,
+  // the Web Store, PDF viewers, extension option pages, devtools, etc. —
+  // sending to them produces "Receiving end does not exist" rejections
+  // that clutter the console without representing a real failure.
+  tabs.forEach(function (tab) {
+    if (tab.id == null) return
+    if (!/^https?:\/\//.test(tab.url ?? '')) return
+    // Swallow the rejection — it's expected for tabs whose content script
+    // hasn't (yet) registered a listener, and the send is fire-and-forget.
+    chrome.tabs.sendMessage(tab.id, message).catch(() => { /* expected */ })
   })
 }
 


### PR DESCRIPTION
Fixes #45.

Silences the "Receiving end does not exist" console flood reported by M during the Alpha-Gold demo attempt. The extension was never functionally broken — it correctly validates images on real webpages — but the service worker was emitting "Uncaught (in promise) Error" rejections for every non-http(s) tab it tried to message, making the console unusable.

## Changes

1. `src/utils.ts` — `sendMessageToAllTabs`: now filters to `http(s)` tabs and attaches `.catch(() => {})` on each dispatch.
2. `src/background.ts` — three `chrome.tabs.sendMessage` call sites now attach `.catch(() => {})`.

## Release plan

Merge → rebuild `dist/chrome/` → cut `v1.0.0-rc4` → bump the verifieddit-www `/download` page's `RELEASE_TAG` + `RELEASE_SHA256` + `RELEASE_SIZE` → flake FOD hash will need another bump (tracked separately).
