### PR TITLE
fix(#57): rc8 — stop bundling c2pa into content.js, fix onReady/overlay races, add About-tab dl

### DIFF
--- a/public/popup.css
+++ b/public/popup.css
@@ -75,3 +75,38 @@
     visibility: visible;
     opacity: 1;
 }
+/* Build info DL — renders the Version / Tag / Commit / Built grid in the
+ * About tab. Populated at runtime by popup.ts from the generated
+ * src/build-info.ts constants (#57). */
+.build-info {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 4px 12px;
+    margin-top: 8px;
+    font-size: 12px;
+    color: #333;
+}
+.build-info dt {
+    color: #777;
+    font-weight: 600;
+}
+.build-info dd {
+    margin: 0;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    word-break: break-all;
+}
+.build-info dd a {
+    color: #0b5ed7;
+    text-decoration: none;
+}
+.build-info dd a:hover {
+    text-decoration: underline;
+}
+.build-info-dim {
+    color: #999;
+    font-size: 11px;
+}
+.version-name {
+    color: #555;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}

--- a/public/popup.html
+++ b/public/popup.html
@@ -31,12 +31,24 @@
 
         <div id="about" class="tab-content">
             <h1>Verifieddit</h1>
-            <p>Version <span id="version">1.0.0</span></p>
             <p>Verify content authenticity using <a href="https://c2pa.org/" target="_blank">C2PA
                     Content Credentials</a>. Detect AI-generated and edited media directly in your browser.</p>
 
             <p>Visit <a href="https://verifieddit.com" target="_blank">verifieddit.com</a>
                 for more information.</p>
+
+            <hr>
+            <dl id="build-info" class="build-info">
+                <dt>Version</dt>
+                <dd><span id="version">1.0.0</span> <span id="version-name" class="version-name"></span></dd>
+                <dt>Tag</dt>
+                <dd><a id="tag-link" href="#" target="_blank"><span id="tag-describe">unknown</span></a></dd>
+                <dt>Commit</dt>
+                <dd><a id="commit-link" href="#" target="_blank"><span id="commit-short">unknown</span></a>
+                    <span id="commit-branch" class="build-info-dim"></span></dd>
+                <dt>Built</dt>
+                <dd><span id="build-date">—</span> <span id="build-host" class="build-info-dim"></span></dd>
+            </dl>
         </div>
 
         <div id="options" class="tab-content">

--- a/src/content.ts
+++ b/src/content.ts
@@ -5,7 +5,11 @@
 
 import { MSG_DISPLAY_C2PA_OVERLAY, MSG_FRAME_CLICK, MSG_REMOTE_INSPECT_URL } from './constants'
 import { C2paOverlay } from './overlay'
-import { validateUrl } from './c2pa' // Import validateUrl
+// NOTE (#57): do not import c2pa here. c2pa spawns a Worker from
+// chrome-extension://.../c2pa.worker.js which is blocked when the content
+// script runs on a web origin. The real validation path goes through
+// inject.ts -> MSG_VALIDATE_URL -> background service worker, where the
+// Worker is allowed.
 
 export type MediaElement = (HTMLImageElement | HTMLVideoElement | HTMLAudioElement)
 
@@ -58,46 +62,6 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   }
 })
 
-// Function to process a single image element
-async function processImage(img: HTMLImageElement): Promise<void> {
-  // Check if the image is larger than 50x50 pixels
-  if (img.naturalWidth > 50 && img.naturalHeight > 50) {
-    console.debug(`Processing image: ${img.src}`);
-    try {
-      const result = await validateUrl(img.src);
-      if ('manifestStore' in result) {
-        console.log(`C2PA data found for image: ${img.src}`, result);
-      } else {
-        console.log(`No C2PA data found for image: ${img.src}`, result);
-      }
-    } catch (error) {
-      console.error(`Error processing image ${img.src}:`, error);
-    }
-  } else {
-    console.debug(`Skipping image (too small): ${img.src}`);
-  }
-}
-
-// Observe the DOM for new images
-const observer = new MutationObserver((mutations) => {
-  mutations.forEach((mutation) => {
-    mutation.addedNodes.forEach((node) => {
-      if (node.nodeName === 'IMG') {
-        void processImage(node as HTMLImageElement);
-      } else if (node.nodeType === Node.ELEMENT_NODE) {
-        // Check for images within added elements
-        (node as Element).querySelectorAll('img').forEach((img) => {
-          void processImage(img);
-        });
-      }
-    });
-  });
-});
-
-// Start observing the document body for added nodes
-observer.observe(document.body, { childList: true, subtree: true });
-
-// Process existing images on the page
-document.querySelectorAll('img').forEach((img) => {
-  void processImage(img);
-});
+// Duplicate image-processing observer removed (#57). inject.ts is the single
+// source of truth for image discovery + validation. This script only bridges
+// overlay messages between the background worker and the page.

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -406,8 +406,11 @@ VisibilityMonitor.onEnterViewport((mediaRecord: MediaRecord): void => {
     // Check image dimensions for icon injection
     if (mediaRecord.element.tagName === 'IMG') {
       const imgElement = mediaRecord.element as HTMLImageElement;
-      // Use onReady to ensure dimensions are available
-      mediaRecord.onReady = () => {
+      // Capture the ready-callback locally so we can invoke it directly
+      // for already-loaded images. mediaRecord.onReady is a setter-only
+      // property on MediaRecord — reading it returns undefined, so we
+      // cannot round-trip through it (#57).
+      const onReadyCallback = (): void => {
         if (imgElement.naturalWidth > 5 && imgElement.naturalHeight > 5) {
           console.debug('Image meets size criteria, creating/updating icon:', mediaRecord.src);
           // Create icon with a default status if it doesn't exist
@@ -464,9 +467,10 @@ console.debug('Removing CrIcon due to size criteria in onEnterViewport for:', me
           }
         }
       };
+      mediaRecord.onReady = onReadyCallback;
       // Trigger onReady logic immediately if the image is already loaded
       if (imgElement.complete && imgElement.naturalWidth !== 0) {
-          mediaRecord.onReady(mediaRecord);
+          onReadyCallback();
       }
     } else {
        // For non-image media elements (video, audio), proceed with C2PA validation

--- a/src/overlayFrame.ts
+++ b/src/overlayFrame.ts
@@ -5,6 +5,7 @@
 
 import { MSG_DISPLAY_C2PA_OVERLAY, MSG_FORWARD_TO_CONTENT, MSG_UPDATE_FRAME_HEIGHT, MSG_OPEN_OVERLAY } from './constants'
 import { type C2paOverlay } from './webComponents'
+import { type C2paResult } from './c2pa'
 
 console.debug('%cFRAME:', 'color: blue', window.location.href)
 
@@ -14,17 +15,24 @@ export interface FrameMessage {
   data: unknown
 }
 
-let _overlay: C2paOverlay
+let _overlay: C2paOverlay | null = null
+// Buffer overlay messages that arrive before window.onload fires (#57).
+let _pendingOverlay: { c2paResult: C2paResult, position: { x: number, y: number } } | null = null
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   /*
     Populate the IFrame with C2PA validation results for a media element.
   */
   if (message.action === MSG_OPEN_OVERLAY) {
-    const c2paResult = message.data.c2paResult
+    const c2paResult = message.data.c2paResult as C2paResult
     const position = message.data.position as { x: number, y: number }
-    _overlay.c2paResult = c2paResult
-    sendToContent({ action: MSG_DISPLAY_C2PA_OVERLAY, data: { position } })
+    if (_overlay !== null) {
+      _overlay.c2paResult = c2paResult
+      sendToContent({ action: MSG_DISPLAY_C2PA_OVERLAY, data: { position } })
+    } else {
+      // window.onload hasn't fired yet — buffer and apply on load
+      _pendingOverlay = { c2paResult, position }
+    }
   }
 })
 
@@ -36,6 +44,11 @@ window.onload = () => {
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   _overlay = document.querySelector('c2pa-overlay')!
   resizeObserver.observe(document.body)
+  if (_pendingOverlay !== null) {
+    _overlay.c2paResult = _pendingOverlay.c2paResult
+    sendToContent({ action: MSG_DISPLAY_C2PA_OVERLAY, data: { position: _pendingOverlay.position } })
+    _pendingOverlay = null
+  }
 }
 
 const resizeObserver = new ResizeObserver(entries => {


### PR DESCRIPTION
Four runtime failures seen on rc7. Full analysis in issue #57. 5 files: content.ts, inject.ts, overlayFrame.ts, popup.html, popup.css. content.js shrinks 401KB → 2KB. tsc clean. Fixes #57