### PR TITLE
fix(#70): rc11.2 — overlay panel now renders opaque, sized, and on top

### DIFF
--- a/public/iframe.css
+++ b/public/iframe.css
@@ -1,90 +1,27 @@
+/* rc11.2 / #70 — iframe body is the frame around the <c2pa-overlay>
+ * custom element. Keep it opaque white and let the web component
+ * define its own width/height. Previously this file still carried the
+ * pre-rename placeholder layout (flex-centring viewport-units, dark
+ * semi-transparent background scrim) which caused the iframe to paint
+ * as a 2px-tall transparent slit against the demo page. The
+ * <c2pa-overlay> custom element owns its own rendering now; all this
+ * stylesheet needs to do is ensure the iframe surface is opaque and
+ * the web component takes up block-level space. */
+
+html, body {
+    margin: 0;
+    padding: 0;
+    background: #ffffff;
+    color-scheme: light;
+    font-family: 'Roboto', Arial, Helvetica, sans-serif;
+}
+
 body {
-    margin: 0;
-    padding: 0;
-    font-family: sans-serif;
-    background-color: rgba(0, 0, 0, 0.5);
-    /* Semi-transparent background */
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    height: 100vh;
-    width: 100vw;
+    min-height: 100%;
     overflow: hidden;
-    /* Prevent scrolling on the body */
 }
 
-.overlay-container {
-    background-color: #fff;
-    border-radius: 8px;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-    width: 90%;
-    /* Adjust as needed */
-    max-width: 800px;
-    /* Adjust as needed */
-    overflow: hidden;
-    /* Keep content within bounds */
-    display: flex;
-    flex-direction: column;
-    max-height: 90vh;
-    /* Limit height to prevent overflow */
-}
-
-.overlay-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 10px 20px;
-    background-color: #f0f0f0;
-    border-bottom: 1px solid #ccc;
-}
-
-.overlay-header h2 {
-    margin: 0;
-    font-size: 1.2em;
-}
-
-#close-button {
-    background: none;
-    border: none;
-    font-size: 1.5em;
-    cursor: pointer;
-    padding: 0;
-}
-
-.overlay-content {
-    display: flex;
-    flex-grow: 1;
-    /* Allow content to take available space */
-    overflow-y: auto;
-    /* Add scroll if content overflows vertically */
-}
-
-.image-container {
-    flex: 1;
-    /* Take equal space */
-    padding: 20px;
-    display: flex;
-    justify-content: center;
-    align-items: flex-start;
-    /* Align image to top */
-    overflow: hidden;
-    /* Hide overflowing image parts */
-}
-
-#provenance-image {
-    max-width: 100%;
-    /* Ensure image fits container */
-    max-height: 100%;
-    /* Ensure image fits container */
-    object-fit: contain;
-    /* Scale image while maintaining aspect ratio */
-}
-
-.provenance-data {
-    flex: 1;
-    /* Take equal space */
-    padding: 20px;
-    border-left: 1px solid #eee;
-    overflow-y: auto;
-    /* Add scroll if data overflows vertically */
+c2pa-overlay {
+    display: block;
+    width: 100%;
 }

--- a/src/overlay.ts
+++ b/src/overlay.ts
@@ -16,17 +16,34 @@ export class C2paOverlay /* extends HTMLElement */ {
     iframe.className = 'c2paDialog'
     iframe.src = `${chrome.runtime.getURL('iframe.html')}`
     iframe.tabIndex = 0
-    iframe.style.cssText = `
-    position: absolute;
-    z-index: ${OVERLAY_Z_INDEX};
-    visibility: hidden;
-    resize: none;
-    overflow: hidden;
-    background: none;
-    border-radius: 5px;
-    border: 1px solid #DDDDDD;
-    box-shadow: 0px 0px 12px 0px rgba(0, 0, 0, 0.2);
-  `.replace(';', '!important;')
+    // rc11.2 / #70 — give the iframe real default dimensions + an opaque
+    // background so it's actually a visible panel on first paint rather than
+    // a 302×2 transparent slit hidden behind the page content. Width /
+    // min-height match the :host min-dimensions on <c2pa-overlay> so the
+    // ResizeObserver → MSG_UPDATE_FRAME_HEIGHT path has something to latch
+    // onto. color-scheme:light nails the iframe to a white background even
+    // under UA dark-mode to avoid the panel rendering dark-on-dark.
+    // Every rule gets `!important` — the overlay is injected into arbitrary
+    // third-party pages whose own CSS can reset position/z-index/width, and
+    // in the rc11/rc10 field reports the panel was rendering behind page
+    // content with an effective height of 2px. The previous single-
+    // `.replace(';', '!important;')` only hardened the first declaration.
+    const important = (rules: Record<string, string>): string =>
+      Object.entries(rules).map(([k, v]) => `${k}: ${v} !important`).join('; ')
+    iframe.style.cssText = important({
+      position: 'absolute',
+      'z-index': String(OVERLAY_Z_INDEX),
+      visibility: 'hidden',
+      resize: 'none',
+      overflow: 'hidden',
+      background: '#ffffff',
+      'color-scheme': 'light',
+      width: '340px',
+      'min-height': '180px',
+      'border-radius': '6px',
+      border: '1px solid #DDDDDD',
+      'box-shadow': '0px 4px 16px rgba(0, 0, 0, 0.18)'
+    })
     this._iframe = iframe
     this.hide()
 

--- a/src/webComponents.ts
+++ b/src/webComponents.ts
@@ -24,6 +24,19 @@ interface IconTextItem {
 
 const sharedStyles = css`
     :host {
+        /* Custom elements default to display:inline, which collapses the host
+         * to zero layout height. The overlay lives inside iframe.html where
+         * the parent iframe sizes itself off document.body via ResizeObserver
+         * + MSG_UPDATE_FRAME_HEIGHT; if :host doesn't contribute height, the
+         * iframe ends up ~2px tall and the panel is effectively invisible
+         * (rc11.2 / issue #70). Force a block host with an opaque default
+         * background so the iframe has real content to render against.
+         */
+        display: block;
+        background: #FFFFFF;
+        min-width: 280px;
+        min-height: 160px;
+        /* Theme tokens consumed by the rest of the component tree. */
         --background: #FFFFFF;
         --border-color: #DDDDDD;
         --background-highlight: #F4F4F4;

--- a/test/e2e/cr-click.spec.ts
+++ b/test/e2e/cr-click.spec.ts
@@ -128,6 +128,34 @@ test.describe('CR overlay click (issue #65)', () => {
       // Give the iframe a moment to populate via MSG_DISPLAY_C2PA_OVERLAY
       await page.waitForTimeout(2_000)
 
+      // rc11.2 / #70 — the iframe must actually be visually visible, not a
+      // 302×2 transparent slit hidden behind the page content. Assert:
+      //   1. elementsFromPoint(centre) returns the iframe as top-of-stack.
+      //   2. the iframe has non-trivial width AND height (≥ 180×120 px).
+      //   3. the iframe rect overlaps the current viewport.
+      const stacking = await page.evaluate(() => {
+        const d = [...document.querySelectorAll('iframe')].find(f => f.className === 'c2paDialog')
+        if (d == null) return null
+        const r = d.getBoundingClientRect()
+        const cx = r.x + r.width / 2
+        const cy = r.y + r.height / 2
+        const top = document.elementsFromPoint(cx, cy)[0]
+        return {
+          rect: { x: r.x, y: r.y, w: r.width, h: r.height },
+          topIsIframe: top === d,
+          topTag: top?.tagName,
+          topCls: (top as HTMLElement | null)?.className?.toString().slice(0, 80),
+          inViewport: r.width > 0 && r.height > 0 &&
+            r.right > 0 && r.bottom > 0 &&
+            r.left < window.innerWidth && r.top < window.innerHeight
+        }
+      })
+      expect(stacking, 'overlay iframe must exist for stacking check').not.toBeNull()
+      expect(stacking!.inViewport, `overlay iframe must land inside the viewport; got rect ${JSON.stringify(stacking!.rect)}`).toBe(true)
+      expect(stacking!.rect.w, 'overlay width must be ≥ 180 px').toBeGreaterThanOrEqual(180)
+      expect(stacking!.rect.h, `overlay height must be ≥ 120 px; got ${stacking!.rect.h} — probably <c2pa-overlay> host had display:inline or iframe had no min-height`).toBeGreaterThanOrEqual(120)
+      expect(stacking!.topIsIframe, `overlay iframe must be topmost at its centre; got ${stacking!.topTag}.${stacking!.topCls} — probably a page element has a higher z-index or the overlay is transparent`).toBe(true)
+
       // Diagnostic logs we expect to have emitted
       expect(consoleLogs.some(l => l.includes('CrIcon onclick fired')), 'CrIcon click handler must fire').toBe(true)
       expect(consoleLogs.some(l => l.includes('overlayFrame: MSG_OPEN_OVERLAY received')), 'overlayFrame must hear MSG_OPEN_OVERLAY').toBe(true)


### PR DESCRIPTION
Closes #70.

## Problem

On https://www.verifieddit.com/demo with rc11 / rc11.1, clicking a CR badge did open the overlay — but the panel rendered as a 302 × **2** px **transparent** slit hidden behind the page content (CDP-measured iframe rect: width 302, height 2; computed background rgba(0, 0, 0, 0)).

The existing E2E (`test/e2e/cr-click.spec.ts`) missed this because it only asserted `visibility === "visible"` + shadow-DOM text content. It didn't check real layout. **My TDD gap, acknowledged.** Spec now has three new stacking assertions (see below).

## Root cause — three reinforcing defects

1. **`<c2pa-overlay>` `:host` defaulted to `display: inline`** (the Lit default for custom elements), so the element contributed zero layout height. The iframe's ResizeObserver on `document.body` measured ~2 px and sent `MSG_UPDATE_FRAME_HEIGHT` = 2.
2. **Iframe inline CSS was transparent** and only the first rule was hardened — the previous `.replace(';', '!important;')` substitutes only the first `;`, so `position: absolute` got `!important` but `background: none`, `z-index`, `width`, etc. were ordinary declarations that arbitrary page CSS could override.
3. **`public/iframe.css` still had the pre-rename placeholder layout**: a flex-centred viewport body with `rgba(0, 0, 0, 0.5)` scrim and a `.overlay-container` block that no longer exists (we replaced it with `<c2pa-overlay></c2pa-overlay>` in rc11). Net effect: opaque iframe background was gone.

## Fix

- **`src/webComponents.ts`** — `:host` now sets `display: block`, `min-width: 280`, `min-height: 160`, opaque white background. The custom element takes real layout space; the ResizeObserver sees a non-trivial height immediately.
- **`src/overlay.ts`** — every inline iframe rule now carries `!important` (new `important({...})` helper replaces the broken `.replace(';', '!important;')`). The iframe gets fixed `width: 340`, `min-height: 180`, `background: #ffffff`, `color-scheme: light`, tightened box-shadow/border-radius.
- **`public/iframe.css`** — rewritten to a minimal stylesheet: opaque white `html, body`, no flex-centring, `c2pa-overlay { display: block; width: 100%; }`.

## Regression gate extended

`test/e2e/cr-click.spec.ts` now asserts the three things that failed in the field:

```ts
expect(stacking.inViewport).toBe(true)
expect(stacking.rect.w).toBeGreaterThanOrEqual(180)
expect(stacking.rect.h).toBeGreaterThanOrEqual(120)
expect(stacking.topIsIframe).toBe(true)  // document.elementsFromPoint(cx, cy)[0] === iframe
```

Verified on the rc11.2 build (headed chromium on ai.matthewstevens.org):

- iframe rect: **340 × 312** (was 302 × 2)
- `bgColor: rgb(255, 255, 255)` (was `rgba(0, 0, 0, 0)`)
- `topAtCenter[0] = c2paDialog iframe` — overlay is topmost at its centre
- All 3 E2E specs green (cr-click + 2 × popup-about-and-trustlists).

## Test plan
- [x] `npx playwright test test/e2e/cr-click.spec.ts` green with the new stacking/size/topmost assertions
- [x] All other specs still green
- [ ] Manual: load rc11.2 unpacked on /demo, click any CR badge → full opaque panel, Signer + Trust list + Cert chain all legible

🤖 Generated with [Claude Code](https://claude.com/claude-code)