### PR TITLE
fix(#74): rc11.3 — strip Microsoft Content Integrity branding leak

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -77,19 +77,11 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   }
 
   if (action === MSG_L3_INSPECT_URL) {
+    // Open verifieddit.com with the image URL pre-populated via ?url=.
+    // (#74) Replaces the upstream "paste into Microsoft Content Integrity's
+    // HTMLInputElement via MutationObserver" dance, which was tied to
+    // Microsoft's page DOM and is no longer the target validator page.
     void openOrSwitchToTab(data as string)
-      .then(async tab => {
-        if (tab.id == null) {
-          return
-        }
-        const id = tab.id
-        // TODO: when the tab is newly created, the content script may not be ready to receive the message.
-        // This is a temporary workaround to wait for the content script to be ready.
-        // We should have the content script send a message to the background script when it is ready. Then we can remove this timeout.
-        setTimeout(() => {
-          chrome.tabs.sendMessage(id, { action: MSG_REMOTE_INSPECT_URL, data }).catch(() => { /* content script may not yet be ready */ })
-        }, 1000)
-      })
   }
 
   if (action === MSG_FORWARD_TO_CONTENT && tabId != null) {
@@ -172,23 +164,14 @@ async function init (): Promise<void> {
   })
 }
 
-async function openOrSwitchToTab (url: string): Promise<chrome.tabs.Tab> {
-  const openTabs = await chrome.tabs.query({ url: REMOTE_VALIDATION_LINK })
-
-  let tab: chrome.tabs.Tab
-
-  if (openTabs.length > 0) {
-    tab = openTabs[0]
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    await chrome.tabs.update(tab.id!, { active: true })
-    if (tab.windowId != null) {
-      await chrome.windows.update(tab.windowId, { focused: true })
-    }
-  } else {
-    tab = await chrome.tabs.create({ url: REMOTE_VALIDATION_LINK })
-  }
-
-  return tab
+async function openOrSwitchToTab (imageUrl: string): Promise<chrome.tabs.Tab> {
+  // Build the Verifieddit /check URL with the image URL as a query parameter.
+  // (#74) Always open a NEW tab — reusing the existing tab loses the previous
+  // inspection, and matching a pre-existing tab by REMOTE_VALIDATION_LINK
+  // exactly no longer works once the URL carries per-image query params.
+  const target = new URL(REMOTE_VALIDATION_LINK)
+  target.searchParams.set('url', imageUrl)
+  return await chrome.tabs.create({ url: target.toString() })
 }
 
 // trust list refresh alarm (run once a day) TODO: create an option

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -46,7 +46,11 @@ export const MSG_PING_OFFSCREEN = 'MSG_PING_OFFSCREEN'
 export const MSG_OFFSCREEN_KEEPALIVE = 'MSG_OFFSCREEN_KEEPALIVE'
 
 export const DEFAULT_MSG_TIMEOUT = 5000 /* 5 sec */
-export const REMOTE_VALIDATION_LINK = 'https://contentintegrity.microsoft.com/check'
+// Verifieddit's own in-browser validator page — replaces the upstream
+// Microsoft Content Integrity deep-link (#74). The extension opens this
+// URL with `?url=<encoded image src>` appended; the receiving page is
+// expected to auto-fill its URL input from the query param.
+export const REMOTE_VALIDATION_LINK = 'https://www.verifieddit.com/'
 export const AWAIT_ASYNC_RESPONSE = true
 export const AUTO_SCAN_DEFAULT = process.env.AUTO_SCAN?.toLowerCase() === 'true' || false
 export const TRUSTLIST_UPDATE_INTERVAL = 1440 /* 24 hours */

--- a/src/content.ts
+++ b/src/content.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT license.
  */
 
-import { MSG_DISPLAY_C2PA_OVERLAY, MSG_FRAME_CLICK, MSG_REMOTE_INSPECT_URL } from './constants'
+import { MSG_DISPLAY_C2PA_OVERLAY, MSG_FRAME_CLICK } from './constants'
 import { C2paOverlay } from './overlay'
 // NOTE (#57): do not import c2pa here. c2pa spawns a Worker from
 // chrome-extension://.../c2pa.worker.js which is blocked when the content
@@ -20,29 +20,11 @@ console.debug('%cCONTENT:', 'color: cornsilk', window.location.href)
 */
 const overlay = C2paOverlay.overlay
 
-/*
-  The https://contentintegrity.microsoft.com/check page does not support validating a url from a query parameter.
-  So we have the extension detect when the https://contentintegrity.microsoft.com/check is active and paste the url into the input field.
-  This assumes that the page structure does not change.
-*/
-function pasteUrlIntoInput (url: string): void {
-  // are we already on the validation where we have to click the 'Check another file' button?
-  const checkAnotherFileButton = Array.from(document.querySelectorAll('button')).find(button => button.textContent?.trim() === 'Check another file')
-  if (checkAnotherFileButton != null) {
-    checkAnotherFileButton.click()
-  }
-
-  // If the above button was clicked, we need to queue the URL to be pasted after the page has transitioned
-  setTimeout(() => {
-    const textInput: HTMLInputElement | null = document.querySelector('input[type="text"]')
-    if (textInput == null) {
-      return
-    }
-    textInput.value = decodeURIComponent(url)
-    // send input event or page will believe the input is still empty
-    textInput.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }))
-  }, 0)
-}
+// #74: the upstream "paste the URL into Microsoft Content Integrity's
+// search box via MutationObserver" plumbing (MSG_REMOTE_INSPECT_URL +
+// pasteUrlIntoInput) is gone. The extension now opens verifieddit.com
+// with `?url=<encoded>` in background.ts and lets the receiving page
+// auto-fill from the query param. Nothing to do in the content script.
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   /*
@@ -50,11 +32,6 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   */
   if (message.action === MSG_DISPLAY_C2PA_OVERLAY) {
     overlay.show(message.data.position.x as number, message.data.position.y as number)
-  }
-
-  if (message.action === MSG_REMOTE_INSPECT_URL) {
-    const url = message.data as string
-    pasteUrlIntoInput(url)
   }
 
   if (message.action === MSG_FRAME_CLICK) {

--- a/src/webComponents.ts
+++ b/src/webComponents.ts
@@ -460,7 +460,7 @@ export class C2paOverlay extends LitElement {
       </div>
       ${this.validationSection(c2paResult.manifestStore.validationStatus)}
       <div id="inspectionLink">
-          For more details, inspect the image in the <span id="mciLink" @click="${this.handleClick}"><u>Microsoft Content Integrity</u></span> page.
+          For more details, inspect this image on the <span id="mciLink" @click="${this.handleClick}"><u>Verifieddit</u></span> page.
       </div>
       <!-- <div class="additional-info" style="display: ${this.additionalInfoCollapsed ? 'none' : 'flex'};"> -->
       <div class="additional-info">

--- a/test/e2e/cr-click.spec.ts
+++ b/test/e2e/cr-click.spec.ts
@@ -181,6 +181,28 @@ test.describe('CR overlay click (issue #65)', () => {
       expect(panel.trustList, 'trust list must read "unknown" for the CBC fixture').toBe('unknown')
       expect(panel.shadowText, 'overlay must show the signer').toContain('CBC/Radio-Canada')
       expect(panel.shadowText, 'overlay must indicate signer is unknown to current trust list').toMatch(/unknown/i)
+
+      // rc11.3 / #74 — the overlay's "For more details" inspection copy must
+      // point at Verifieddit, not the upstream Microsoft Content Integrity
+      // page. Assert both the user-visible text and the absence of the old
+      // microsoft.com host in any link-bearing attribute of the shadow tree.
+      const linkAudit = await iframeFrame!.evaluate(() => {
+        const overlay = document.querySelector('c2pa-overlay') as unknown as { shadowRoot: ShadowRoot | null }
+        const root = overlay?.shadowRoot
+        const text = (root?.textContent ?? '').replace(/\s+/g, ' ').trim()
+        const allEls = root != null ? Array.from(root.querySelectorAll('*')) : []
+        const hasMicrosoftHost = allEls.some((el) => {
+          for (const a of el.getAttributeNames()) {
+            const v = el.getAttribute(a) ?? ''
+            if (v.includes('contentintegrity.microsoft.com')) return true
+          }
+          return false
+        }) || text.includes('contentintegrity.microsoft.com')
+        return { text, hasMicrosoftHost }
+      })
+      expect(linkAudit.text, 'overlay must not mention "Microsoft Content Integrity"').not.toMatch(/microsoft content integrity/i)
+      expect(linkAudit.text, 'overlay must offer a Verifieddit details page').toMatch(/verifieddit/i)
+      expect(linkAudit.hasMicrosoftHost, 'no attribute or text may reference contentintegrity.microsoft.com').toBe(false)
     } finally {
       await ctx.close()
     }


### PR DESCRIPTION
Closes #74. Replaces upstream-fork bleed-through that sent users to contentintegrity.microsoft.com. Now points at verifieddit.com/?url=<image>. E2E locked in against regression. Verified 0 microsoft.com refs in shipped dist.