### PR TITLE
feat(#72): rc12 — verifieddit.com API client + credential-recovery fallback

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -13,6 +13,7 @@ import {
   MSG_LOG_MESSAGE, MSG_GET_LOGS, TRUSTLIST_UPDATE_INTERVAL
 } from './constants'
 import { sendMessageToAllTabs } from './utils'
+import { validateImageUrl as apiValidate, isApiFailure } from './verifiedditApi'
 
 const MAX_LOG_ENTRIES = 200 // Limit the number of log entries to store
 let extensionLogs: string[] = []
@@ -117,10 +118,21 @@ async function validateUrl (url: string): Promise<C2paResult | C2paError> {
   const c2paResult = await c2paValidateUrl(url);
   
   if (c2paResult instanceof Error) {
+    // rc12 / #72 — before giving up, ask verifieddit.com /api/v1/validate
+    // if it can recover a credential for this image via perceptual-hash
+    // lookup against the Manifest Store. Failure is logged but never
+    // rethrows the original error — the API path is additive.
+    console.warn(`Background: validateUrl: local c2pa.read threw (${c2paResult.message}). Trying verifieddit.com API fallback for ${url}…`);
+    const apiResult = await apiValidate(url);
+    if (!isApiFailure(apiResult) && apiResult.recovery != null) {
+      const synth = synthesiseRecoveredC2paResult(url, apiResult);
+      console.debug(`Background: validateUrl: recovered credential from API for ${url}:`, synth);
+      return synth;
+    }
     console.error(`Background: validateUrl: Error from c2paValidateUrl for ${url}:`, c2paResult);
     return c2paResult;
   }
-  
+
   console.debug(`Background: validateUrl: Initial c2paResult for ${url}:`, c2paResult);
   
   // Check trust list inclusion
@@ -136,8 +148,60 @@ async function validateUrl (url: string): Promise<C2paResult | C2paError> {
     console.debug(`Background: validateUrl: No TST tokens found for ${url}.`);
   }
 
+  // rc12 / #72 — if c2pa-js returned a "No Manifest" sentinel (C2paError),
+  // try recovering a durable credential from verifieddit.com. The
+  // c2paValidateUrl path at src/c2pa.ts:72-74 returns a C2paError shape
+  // (not an Error) when the file is unsigned; detect that by the absent
+  // manifestStore.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if ((c2paResult as any)?.manifestStore == null) {
+    console.debug(`Background: validateUrl: unsigned image, trying verifieddit.com /api/v1/validate for ${url}…`);
+    const apiResult = await apiValidate(url);
+    if (!isApiFailure(apiResult) && apiResult.recovery != null) {
+      const synth = synthesiseRecoveredC2paResult(url, apiResult);
+      console.debug(`Background: validateUrl: recovered credential from API for ${url}:`, synth);
+      return synth;
+    }
+  }
+
   console.debug(`Background: validateUrl: Final c2paResult before returning for ${url}:`, c2paResult);
   return c2paResult;
+}
+
+/**
+ * Build a c2pa-shaped result from the /api/v1/validate recovery block so the
+ * existing inject.ts / webComponents.ts rendering path can show it without
+ * needing a parallel "recovered-credential" type. The new result carries a
+ * marker (`recovered: true`) that downstream code can check to add UX
+ * affordances — see rc12.1 for the overlay panel copy.
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+function synthesiseRecoveredC2paResult (url: string, api: { recovery: NonNullable<Awaited<ReturnType<typeof apiValidate>> extends infer T ? T extends { recovery: unknown } ? T['recovery'] : never : never> } & Record<string, unknown>) {
+  const rec = api.recovery!
+  return {
+    url,
+    recovered: true as const,
+    recoveryMethod: rec.method,
+    recoverySimilarityScore: rec.similarityScore,
+    recoveryNote: rec.explanatoryNote,
+    source: { filename: rec.originalFilename ?? '', type: 'image/unknown', thumbnail: { type: '', data: '' } },
+    manifestStore: {
+      manifests: {
+        [rec.manifestId]: {
+          title: rec.originalFilename ?? rec.manifestId,
+          signatureInfo: { issuer: rec.signerCn ?? '(unknown)', time: rec.signedAt ?? '' },
+          ingredients: []
+        }
+      },
+      activeManifest: rec.manifestId,
+      validationStatus: []
+    },
+    trustList: null,
+    tsaTrustList: null,
+    certChain: null,
+    tstTokens: null,
+    editsAndActivity: null
+  }
 }
 
 async function init (): Promise<void> {

--- a/src/background.ts
+++ b/src/background.ts
@@ -176,7 +176,7 @@ async function validateUrl (url: string): Promise<C2paResult | C2paError> {
  * can branch on. Returned as `C2paResult` via a deliberate cast since the
  * synth only fills the subset of fields the overlay actually reads.
  */
-function synthesiseRecoveredC2paResult (url: string, api: { recovery: RecoveredCredential | null } & Record<string, unknown>): C2paResult {
+function synthesiseRecoveredC2paResult (url: string, api: { recovery: RecoveredCredential | null }): C2paResult {
   const rec = api.recovery
   if (rec == null) throw new Error('synthesiseRecoveredC2paResult called with no recovery block')
   const manifest = {

--- a/src/background.ts
+++ b/src/background.ts
@@ -13,7 +13,7 @@ import {
   MSG_LOG_MESSAGE, MSG_GET_LOGS, TRUSTLIST_UPDATE_INTERVAL
 } from './constants'
 import { sendMessageToAllTabs } from './utils'
-import { validateImageUrl as apiValidate, isApiFailure } from './verifiedditApi'
+import { validateImageUrl as apiValidate, isApiFailure, type RecoveredCredential } from './verifiedditApi'
 
 const MAX_LOG_ENTRIES = 200 // Limit the number of log entries to store
 let extensionLogs: string[] = []
@@ -172,36 +172,46 @@ async function validateUrl (url: string): Promise<C2paResult | C2paError> {
  * Build a c2pa-shaped result from the /api/v1/validate recovery block so the
  * existing inject.ts / webComponents.ts rendering path can show it without
  * needing a parallel "recovered-credential" type. The new result carries a
- * marker (`recovered: true`) that downstream code can check to add UX
- * affordances — see rc12.1 for the overlay panel copy.
+ * marker (`recovered: true`) on the source side that downstream rc12.1 UX
+ * can branch on. Returned as `C2paResult` via a deliberate cast since the
+ * synth only fills the subset of fields the overlay actually reads.
  */
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function synthesiseRecoveredC2paResult (url: string, api: { recovery: NonNullable<Awaited<ReturnType<typeof apiValidate>> extends infer T ? T extends { recovery: unknown } ? T['recovery'] : never : never> } & Record<string, unknown>) {
-  const rec = api.recovery!
-  return {
+function synthesiseRecoveredC2paResult (url: string, api: { recovery: RecoveredCredential | null } & Record<string, unknown>): C2paResult {
+  const rec = api.recovery
+  if (rec == null) throw new Error('synthesiseRecoveredC2paResult called with no recovery block')
+  const manifest = {
+    title: rec.originalFilename ?? rec.manifestId,
+    format: 'application/c2pa',
+    ingredients: [],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    signatureInfo: { issuer: rec.signerCn ?? '(unknown)', time: rec.signedAt ?? '' } as any
+  }
+  const synth = {
     url,
-    recovered: true as const,
-    recoveryMethod: rec.method,
-    recoverySimilarityScore: rec.similarityScore,
-    recoveryNote: rec.explanatoryNote,
-    source: { filename: rec.originalFilename ?? '', type: 'image/unknown', thumbnail: { type: '', data: '' } },
+    source: {
+      filename: rec.originalFilename ?? '',
+      type: 'image/unknown',
+      thumbnail: { type: '', data: '' },
+      data: ''
+    },
     manifestStore: {
-      manifests: {
-        [rec.manifestId]: {
-          title: rec.originalFilename ?? rec.manifestId,
-          signatureInfo: { issuer: rec.signerCn ?? '(unknown)', time: rec.signedAt ?? '' },
-          ingredients: []
-        }
-      },
-      activeManifest: rec.manifestId,
+      manifests: [manifest],
+      activeManifest: 0,
       validationStatus: []
     },
     trustList: null,
     tsaTrustList: null,
     certChain: null,
     tstTokens: null,
-    editsAndActivity: null
+    editsAndActivity: null,
+    // rc12 extension marker — not in the c2pa-js type but safe to attach.
+    recovered: true,
+    recoveryMethod: rec.method,
+    recoverySimilarityScore: rec.similarityScore,
+    recoveryNote: rec.explanatoryNote
   }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return synth as any as C2paResult
 }
 
 async function init (): Promise<void> {

--- a/src/verifiedditApi.ts
+++ b/src/verifiedditApi.ts
@@ -1,0 +1,163 @@
+/*
+ * Typed client for the verifieddit.com public API.
+ *
+ * The extension already does local in-browser C2PA validation via the
+ * bundled WASM c2pa-js library. That path is fast but can't help with:
+ *   - images with no embedded manifest (Pillar 1 stripped)
+ *   - AI-detection classification
+ *   - durable-credential recovery via perceptual fingerprint lookup
+ *
+ * For those we fan out to the upstream REST endpoints published at
+ * verifieddit.com. Documented via the live implementations at:
+ *   - verifieddit-www/api/routes/validate.js                (/api/v1/validate)
+ *   - verifieddit-www/services/stripe-backend/src/index.ts  (/api/ai-detect)
+ *
+ * Verifieddit.com is NOT a WebMCP site — confirmed 2026-04-24. Rest API only.
+ */
+
+/** Default upstream origin. Overridable via chrome.storage.local.apiBaseUrl. */
+export const DEFAULT_API_ORIGIN = 'https://www.verifieddit.com'
+
+export type ValidateStatus = 'trusted' | 'valid' | 'invalid' | 'unsigned' | 'recovered'
+
+export interface RecoveredCredential {
+  method: 'fingerprint' | 'watermark'
+  similarityScore: number
+  manifestId: string
+  signerCn: string | null
+  signedAt: string | null
+  originalFileHash: string | null
+  originalFilename: string | null
+  explanatoryNote: string
+}
+
+export interface ValidateApiResponse {
+  status: ValidateStatus
+  filename: string
+  fileHash: string
+  fileSize: number
+  /** Shape matches the c2pa-js `read()` result, re-serialised by the server. */
+  c2pa: unknown | null
+  recovery: RecoveredCredential | null
+  trustReceipt: { url: string, format: 'image/png', size: number } | null
+  processedAt: string
+}
+
+export interface AiDetectApiResponse {
+  aiDetected: boolean | null
+  confidence: number | null
+  detectedGenerator: string | null
+  analysisDate: string
+  fileHash: string
+  cached: boolean
+  moderation: {
+    nudity: number
+    gore: number
+    offensive: number
+    weapon: number
+    unsafe: boolean
+    categories: string[]
+  } | null
+  error?: string
+}
+
+export interface ApiFailure { error: string, status: number, code?: string }
+
+function apiOrigin (): string {
+  // TODO (rc12.1): make this configurable via chrome.storage.local so QA
+  // can point the extension at testing.verifieddit.com. For now the ship
+  // build always targets production.
+  return DEFAULT_API_ORIGIN
+}
+
+/**
+ * Fetch image bytes from the given URL (service worker context — arbitrary
+ * origins allowed) and POST to /api/v1/validate. Returns the structured
+ * response or an ApiFailure describing why the call couldn't complete.
+ *
+ * Call sites:
+ *   - background.ts validateUrl(): after local c2pa.read() when the local
+ *     result has no manifest, to recover a credential via perceptual hash.
+ *   - (planned rc12.1) large-media offload — skip local c2pa entirely for
+ *     images above a size threshold and rely on the server.
+ */
+export async function validateImageUrl (imageUrl: string): Promise<ValidateApiResponse | ApiFailure> {
+  try {
+    const fetched = await fetch(imageUrl, { credentials: 'omit', cache: 'default' })
+    if (!fetched.ok) {
+      return { error: `Upstream fetch failed (${fetched.status})`, status: fetched.status }
+    }
+    const blob = await fetched.blob()
+    const fd = new FormData()
+    // The backend multer config expects the field name "image" and the
+    // MIME-type set by the Blob; name defaults to the tail of the URL.
+    const filename = deriveFilename(imageUrl)
+    fd.append('image', blob, filename)
+
+    const endpoint = `${apiOrigin()}/api/v1/validate`
+    const res = await fetch(endpoint, {
+      method: 'POST',
+      credentials: 'omit',
+      body: fd
+    })
+    if (res.status === 429) return { error: 'rate_limit', status: 429, code: 'RATE_LIMIT' }
+    if (!res.ok) {
+      let code: string | undefined
+      try {
+        const body = await res.json() as { code?: string, message?: string }
+        code = body?.code
+      } catch { /* body not JSON */ }
+      return { error: `API ${res.status}`, status: res.status, code }
+    }
+    const body = await res.json() as ValidateApiResponse
+    return body
+  } catch (err) {
+    return { error: (err as Error)?.message ?? 'unknown', status: 0 }
+  }
+}
+
+/**
+ * POST /api/ai-detect with an image URL. The server fetches the image
+ * directly (avoids CORS constraints on the extension side). Returns
+ * the structured response or an ApiFailure.
+ *
+ * Current production requires a Clerk session cookie, but the endpoint
+ * also responds to anonymous cross-origin calls with a generic result
+ * (probed live 2026-04-24) — we include credentials:omit so we never
+ * leak the user's verifieddit.com cookie from unrelated tabs.
+ */
+export async function detectAiForImageUrl (imageUrl: string): Promise<AiDetectApiResponse | ApiFailure> {
+  try {
+    const endpoint = `${apiOrigin()}/api/ai-detect`
+    const res = await fetch(endpoint, {
+      method: 'POST',
+      credentials: 'omit',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        imageUrl,
+        mimeType: 'image/jpeg', // backend auto-sniffs from the URL
+        filename: deriveFilename(imageUrl),
+        origin: 'verifieddit-extension'
+      })
+    })
+    if (res.status === 429) return { error: 'rate_limit', status: 429, code: 'RATE_LIMIT' }
+    if (!res.ok) return { error: `API ${res.status}`, status: res.status }
+    return await res.json() as AiDetectApiResponse
+  } catch (err) {
+    return { error: (err as Error)?.message ?? 'unknown', status: 0 }
+  }
+}
+
+export function isApiFailure<T extends object> (v: T | ApiFailure): v is ApiFailure {
+  return 'status' in v && 'error' in v
+}
+
+function deriveFilename (url: string): string {
+  try {
+    const u = new URL(url)
+    const tail = u.pathname.split('/').pop() ?? 'image'
+    return tail.length > 0 ? tail : 'image'
+  } catch {
+    return 'image'
+  }
+}


### PR DESCRIPTION
Fixes #72.

First slice of the rc12 API integration. Typed client for /api/v1/validate + /api/ai-detect, plus background wiring that falls back to the server when c2pa.read() returns no manifest and synthesises a C2paResult from any recovery block. UX affordances for the recovered state come in rc12.1. All 3 existing E2E specs still green.

Research notes in issue #72 comment: not a WebMCP site, REST only, no auth required on validate, anonymous cross-origin works on ai-detect.