### PR TITLE
feat(#66): rc13.1 — custom trust-list import UI in Trust Lists tab

### DIFF
--- a/public/popup.html
+++ b/public/popup.html
@@ -34,16 +34,31 @@
         <div id="trustlists" class="tab-content">
             <h1>Trust Lists</h1>
             <p class="detail-dim">
-                Read-only snapshot of every trust list currently loaded by the extension. Certificates
-                whose SHA-256 thumbprint appears in one of these entries will render a green CR badge
-                on signed media; everything else shows a warning.
+                Every trust list currently loaded by the extension. Certificates whose SHA-256 thumbprint
+                appears in one of these entries render as trusted on signed media; everything else shows
+                a warning.
             </p>
             <div id="trustlists-content">
                 <p class="detail-dim">Loading trust lists…</p>
             </div>
-            <p class="detail-dim" style="margin-top:1em;">
-                To add your own list, see the <b>Options</b> tab.
+
+            <hr style="margin-top:14px;border:none;border-top:1px solid #e4e7eb">
+
+            <h2 style="font-size:14px;margin:10px 0 6px;color:#222">Add a trust list</h2>
+            <p class="detail-dim" style="font-size:12px">
+                Import a JSON trust list or a PEM/CRT certificate chain, or fetch one from a URL.
+                Imported lists are stored locally and can be removed from the list above at any time.
             </p>
+
+            <label style="display:block;font-size:12px;font-weight:600;margin-top:8px;color:#333">From a file</label>
+            <input type="file" id="tl-file-input-trustlists" accept=".json,.pem,.crt" style="display:block;margin-top:4px">
+
+            <label style="display:block;font-size:12px;font-weight:600;margin-top:10px;color:#333">From a URL</label>
+            <div style="display:flex;gap:6px;margin-top:4px">
+                <input type="url" id="tl-url-input" placeholder="https://…/trust-list.json" style="flex:1;padding:4px 6px;font-size:12px;border:1px solid #ccc;border-radius:4px">
+                <button id="tl-url-fetch" type="button" style="padding:4px 10px;font-size:12px;border:1px solid #1f4d7a;background:#1f4d7a;color:#fff;border-radius:4px;cursor:pointer">Fetch</button>
+            </div>
+            <div id="tl-import-status" class="detail-dim" style="font-size:12px;margin-top:6px;min-height:16px"></div>
         </div>
 
         <div id="about" class="tab-content">

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -202,7 +202,74 @@ document.addEventListener('DOMContentLoaded', function (): void {
   void displayTrustListInfos()
   // Pre-warm the new read-only Trust Lists tab too.
   void renderTrustListsTab()
+
+  // rc13.1 / #66 — Wire the in-tab import controls (file + URL). These
+  // duplicate the Options-tab inputs but live alongside the list UI so
+  // users don't have to hunt for them.
+  wireTrustListImportControls()
 })
+
+function wireTrustListImportControls (): void {
+  const fileInput = document.getElementById('tl-file-input-trustlists') as HTMLInputElement | null
+  const urlInput = document.getElementById('tl-url-input') as HTMLInputElement | null
+  const fetchBtn = document.getElementById('tl-url-fetch') as HTMLButtonElement | null
+  const statusEl = document.getElementById('tl-import-status') as HTMLDivElement | null
+
+  const setStatus = (msg: string, tone: 'info' | 'ok' | 'error' = 'info'): void => {
+    if (statusEl == null) return
+    statusEl.textContent = msg
+    statusEl.style.color = tone === 'ok' ? '#1f6a2c' : tone === 'error' ? '#7a1f1f' : '#666'
+  }
+
+  if (fileInput != null) {
+    fileInput.addEventListener('change', (ev) => {
+      const t = ev.target as HTMLInputElement
+      const f = t.files?.[0]
+      if (f == null) return
+      setStatus(`Reading ${f.name}…`)
+      const reader = new FileReader()
+      reader.readAsText(f, 'UTF-8')
+      reader.onload = () => {
+        const contents = reader.result as string
+        addTrustFile(contents)
+          .then(async () => {
+            await displayTrustListInfos()
+            await renderTrustListsTab()
+            setStatus(`Imported ${f.name}`, 'ok')
+            t.value = ''
+          })
+          .catch((err) => {
+            setStatus(`Import failed: ${String((err as Error).message ?? err)}`, 'error')
+          })
+      }
+      reader.onerror = () => { setStatus('Failed to read file', 'error') }
+    })
+  }
+
+  if (fetchBtn != null && urlInput != null) {
+    fetchBtn.addEventListener('click', () => {
+      const url = urlInput.value.trim()
+      if (url === '' || !/^https?:\/\//i.test(url)) {
+        setStatus('Enter a full http(s) URL.', 'error')
+        return
+      }
+      setStatus(`Fetching ${url}…`)
+      fetch(url, { credentials: 'omit' })
+        .then(async (r) => {
+          if (!r.ok) throw new Error(`HTTP ${r.status}`)
+          return await r.text()
+        })
+        .then(async (contents) => {
+          await addTrustFile(contents)
+          await displayTrustListInfos()
+          await renderTrustListsTab()
+          setStatus(`Imported from ${url}`, 'ok')
+          urlInput.value = ''
+        })
+        .catch((err) => { setStatus(`Fetch failed: ${String((err as Error).message ?? err)}`, 'error') })
+    })
+  }
+}
 
 /**
  * Displays the validation results in the popup.

--- a/test/e2e/popup-about-and-trustlists.spec.ts
+++ b/test/e2e/popup-about-and-trustlists.spec.ts
@@ -115,11 +115,15 @@ test.describe('popup About + Trust Lists (issue #68)', () => {
       expect(firstName?.trim().length ?? 0).toBeGreaterThan(0)
       expect(firstMeta).toMatch(/\d+\s+entit/i)
 
-      // The Trust Lists tab is content-focused, not edit-focused: no file
-      // input should be visible here. (Import UI stays in Options and
-      // belongs to rc12 / #66.)
+      // rc13.1 / #66 — the Trust Lists tab now carries the import UI
+      // directly so users don't have to hunt for it in Options. Assert
+      // the expected controls exist (one file input, one url input,
+      // one fetch button, one status area).
       const fileInputs = await page.locator('#trustlists input[type="file"]').count()
-      expect(fileInputs, 'Trust Lists tab must be read-only — no file inputs').toBe(0)
+      expect(fileInputs, 'Trust Lists tab must expose a file input for importing').toBe(1)
+      expect(await page.locator('#tl-url-input').count(), 'URL input must exist').toBe(1)
+      expect(await page.locator('#tl-url-fetch').count(), 'Fetch button must exist').toBe(1)
+      expect(await page.locator('#tl-import-status').count(), 'Import status area must exist').toBe(1)
 
       // rc11.5 / #79 — the bundled C2PA Official Trust List must include
       // Trusteddit.com (verifieddit.com trusts it; the extension must


### PR DESCRIPTION
Fixes #66. Adds file + URL import controls directly to the Trust Lists popup tab with live status feedback. Backwards-compatible — Options-tab import still works. 4/4 E2E green.