### PR TITLE
chore(#95): Verifieddit rebrand sweep, repo rename to verifieddit-extension, URLs to www.verifieddit.com

### DIFF
--- a/CHROME_WEB_STORE_LISTING.md
+++ b/CHROME_WEB_STORE_LISTING.md
@@ -19,7 +19,7 @@ English
 - **Publisher (displayed on listing):** SanMarcSoft LLC
 - **Developer website:** https://www.verifieddit.com
 - **Marketing site:** https://www.verifieddit.com
-- **Support / contact email:** TBD (SanMarcSoft LLC contact address)
+- **Support / contact email:** support@verifieddit.com (publicly displayed on the listing; mailbox confirmed-by-user 2026-05-17)
 - **Privacy policy URL:** https://www.verifieddit.com/docs/privacy/
 - **Source repository:** https://github.com/Sanmarcsoft/verifieddit-extension
 

--- a/CHROME_WEB_STORE_LISTING.md
+++ b/CHROME_WEB_STORE_LISTING.md
@@ -15,6 +15,16 @@ Developer Tools
 ## Language
 English
 
+## Developer / Publisher Identity
+- **Publisher (displayed on listing):** SanMarcSoft LLC
+- **Developer website:** https://www.verifieddit.com
+- **Marketing site:** https://www.verifieddit.com
+- **Support / contact email:** TBD (SanMarcSoft LLC contact address)
+- **Privacy policy URL:** https://www.verifieddit.com/docs/privacy/
+- **Source repository:** https://github.com/Sanmarcsoft/verifieddit-extension
+
+Listing the LLC as Publisher on the Chrome Web Store requires either (a) submitting from a Google Workspace account on a SanMarcSoft-owned domain, or (b) setting "SanMarcSoft LLC" as the verified Publisher name on an existing CWS developer account. CWS will display the registered publisher name to end users — verify spelling before submit.
+
 ## Single Purpose Description
 Verify the authenticity and provenance of images, videos, and audio on any webpage using the C2PA content credentials standard.
 
@@ -46,12 +56,12 @@ Content Credentials are a new open standard (C2PA) for proving where digital con
 JPEG, PNG, WebP, AVIF, TIFF, SVG, HEIC, MP4, AVI, WAV, MP3, FLAC, PDF, and more.
 
 **Open Source:**
-Built on Microsoft's C2PA Extension Validator. View the source code at https://github.com/Sanmarcsoft/youseddit-extension-validator
+Built on Microsoft's C2PA Extension Validator. View the source code at https://github.com/Sanmarcsoft/verifieddit-extension
 
-Learn more at https://verifieddit.com
+Learn more at https://www.verifieddit.com
 
 ## Privacy Policy URL
-https://verifieddit.com/docs/privacy/
+https://www.verifieddit.com/docs/privacy/
 
 ## Permission Justifications
 

--- a/RENAME_PLAN_verifieddit.md
+++ b/RENAME_PLAN_verifieddit.md
@@ -1,5 +1,7 @@
 # Plan for Renaming Extension to "verifieddit"
 
+> **STATUS: COMPLETE (2026-05-17).** Rebrand executed; GitHub repo renamed from `Sanmarcsoft/youseddit-extension-validator` to `Sanmarcsoft/verifieddit-extension`. This file is retained as historical record. Pulumi resource names in `infra/` deliberately not renamed (would trigger Scaleway bucket destroy/recreate).
+
 This document outlines the steps required to rename the browser extension from "youseddit" to "verifieddit".
 
 ## Identified Occurrences of Current Name

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,4 +1,4 @@
-# Roadmap — youseddit-extension-validator
+# Roadmap — verifieddit-extension
 
 > Source of truth for sequencing. Authoritative backlog lives in GitHub Issues + Milestones; this file is the human-readable narrative. Updates in this file must reference the relevant issue number in the commit message.
 
@@ -6,8 +6,8 @@
 
 ## Now (Alpha-Gold MVP gate)
 
-**Milestone:** [Alpha-Gold MVP Gate](https://github.com/Sanmarcsoft/youseddit-extension-validator/milestone/2) — due **2026-04-25**.
-**Tracking issue:** [#39 — Alpha-Gold MVP demo gate](https://github.com/Sanmarcsoft/youseddit-extension-validator/issues/39).
+**Milestone:** [Alpha-Gold MVP Gate](https://github.com/Sanmarcsoft/verifieddit-extension/milestone/2) — due **2026-04-25**.
+**Tracking issue:** [#39 — Alpha-Gold MVP demo gate](https://github.com/Sanmarcsoft/verifieddit-extension/issues/39).
 **Stimmt decision:** [session `1bb2e7a3-8413-436b-8991-dc308b48c2ce`, decision `f099d3a3-a43c-4e5d-92a5-c9b050f115a7`](https://stimmt.sanmarcsoft.com/session/1bb2e7a3-8413-436b-8991-dc308b48c2ce).
 
 Publishing to the Chrome Web Store cannot resume until M has validated a clean `dist/chrome/` build of the extension on Chrome against the 7-image demo corpus at `ptt.matthewstevens.org/demo`.
@@ -17,14 +17,14 @@ Four defects must be resolved in the rebuilt artefact (P0 + P1); a fifth is defe
 | Priority | Defect | Status | Owner |
 |----------|--------|--------|-------|
 | P0 | Defect 1 — Trusted images show error instead of green trust | open | Q + 007 |
-| P0 | Defect 3 — Ingredient thumbnails don't render in viewer | fix in flight ([PR #40](https://github.com/Sanmarcsoft/youseddit-extension-validator/pull/40)) | Q + 007 |
-| P0 | Defect 5 — Right-click produces no validation icon | fix in flight ([PR #40](https://github.com/Sanmarcsoft/youseddit-extension-validator/pull/40)) | Q + 007 |
+| P0 | Defect 3 — Ingredient thumbnails don't render in viewer | fix in flight ([PR #40](https://github.com/Sanmarcsoft/verifieddit-extension/pull/40)) | Q + 007 |
+| P0 | Defect 5 — Right-click produces no validation icon | fix in flight ([PR #40](https://github.com/Sanmarcsoft/verifieddit-extension/pull/40)) | Q + 007 |
 | P1 | Defect 2 — Warning icons disappear after being set | open | Q + 007 |
-| P2 | Defect 4 — No-C2PA exclamation icon criteria | **deferred to v1.1** → [#42](https://github.com/Sanmarcsoft/youseddit-extension-validator/issues/42) | Q + 007 |
+| P2 | Defect 4 — No-C2PA exclamation icon criteria | **deferred to v1.1** → [#42](https://github.com/Sanmarcsoft/verifieddit-extension/issues/42) | Q + 007 |
 
 ### Active branches and PRs
 
-- [`feature/39-rc2-offscreen-reasons`](https://github.com/Sanmarcsoft/youseddit-extension-validator/tree/feature/39-rc2-offscreen-reasons) — rc2 fix branch; [PR #40](https://github.com/Sanmarcsoft/youseddit-extension-validator/pull/40) covers Defects 3 + 5 (offscreen reasons + ingredient thumbnails).
+- [`feature/39-rc2-offscreen-reasons`](https://github.com/Sanmarcsoft/verifieddit-extension/tree/feature/39-rc2-offscreen-reasons) — rc2 fix branch; [PR #40](https://github.com/Sanmarcsoft/verifieddit-extension/pull/40) covers Defects 3 + 5 (offscreen reasons + ingredient thumbnails).
 - `feature/39-rc2-fixtures` — test corpus and fixtures consolidation for the rebuilt build (owned by the release-consolidation workstream).
 - `feature/39-roadmap-alpha-gold` — this roadmap change.
 
@@ -40,23 +40,23 @@ Four defects must be resolved in the rebuilt artefact (P0 + P1); a fifth is defe
 
 ## Next (CWS submission — parked behind the gate)
 
-**Milestone:** [Alpha-Gold MVP Gate](https://github.com/Sanmarcsoft/youseddit-extension-validator/milestone/2) *(these issues are gated behind #39, not separate.)*
+**Milestone:** [Alpha-Gold MVP Gate](https://github.com/Sanmarcsoft/verifieddit-extension/milestone/2) *(these issues are gated behind #39, not separate.)*
 
 Parked until M greenlights the MVP. Do not progress without explicit reactivation.
 
-- [#37 — CWS v1.0.0 blocker triage](https://github.com/Sanmarcsoft/youseddit-extension-validator/issues/37) (Eleanor's conditional deliverable).
-- [#38 — Technical impact assessment on Phenom PKI](https://github.com/Sanmarcsoft/youseddit-extension-validator/issues/38) (Priya + Q's conditional deliverable).
-- Individual CWS submission blockers: [#32](https://github.com/Sanmarcsoft/youseddit-extension-validator/issues/32) — [#35](https://github.com/Sanmarcsoft/youseddit-extension-validator/issues/35).
-- `CHROME_WEB_STORE_LISTING.md` copy edits ([#34](https://github.com/Sanmarcsoft/youseddit-extension-validator/issues/34)).
+- [#37 — CWS v1.0.0 blocker triage](https://github.com/Sanmarcsoft/verifieddit-extension/issues/37) (Eleanor's conditional deliverable).
+- [#38 — Technical impact assessment on Phenom PKI](https://github.com/Sanmarcsoft/verifieddit-extension/issues/38) (Priya + Q's conditional deliverable).
+- Individual CWS submission blockers: [#32](https://github.com/Sanmarcsoft/verifieddit-extension/issues/32) — [#35](https://github.com/Sanmarcsoft/verifieddit-extension/issues/35).
+- `CHROME_WEB_STORE_LISTING.md` copy edits ([#34](https://github.com/Sanmarcsoft/verifieddit-extension/issues/34)).
 
-The [`Verifieddit v1.0.0 CWS Submission`](https://github.com/Sanmarcsoft/youseddit-extension-validator/milestone/1) milestone (due 2026-05-01) activates only once the Alpha-Gold gate is open.
+The [`Verifieddit v1.0.0 CWS Submission`](https://github.com/Sanmarcsoft/verifieddit-extension/milestone/1) milestone (due 2026-05-01) activates only once the Alpha-Gold gate is open.
 
 ---
 
 ## Later (v1.1 — post-Alpha-Gold polish)
 
-**Milestone:** [v1.1 — post-Alpha-Gold polish](https://github.com/Sanmarcsoft/youseddit-extension-validator/milestone/3) — no due date yet; sequenced after CWS submission.
+**Milestone:** [v1.1 — post-Alpha-Gold polish](https://github.com/Sanmarcsoft/verifieddit-extension/milestone/3) — no due date yet; sequenced after CWS submission.
 
-- [#42 — Defect 4 (v1.1): Define No-C2PA exclamation icon identification criteria](https://github.com/Sanmarcsoft/youseddit-extension-validator/issues/42). Deferred from the Alpha-Gold gate per the Stimmt decision above. Work covers (a) defining which images "should" have C2PA, (b) implementing the exclamation-icon indicator, (c) verifying on the demo corpus plus additional trigger cases.
+- [#42 — Defect 4 (v1.1): Define No-C2PA exclamation icon identification criteria](https://github.com/Sanmarcsoft/verifieddit-extension/issues/42). Deferred from the Alpha-Gold gate per the Stimmt decision above. Work covers (a) defining which images "should" have C2PA, (b) implementing the exclamation-icon indicator, (c) verifying on the demo corpus plus additional trigger cases.
 
 Further v1.1 scope will be added here as items are identified during the MVP gate sprint.

--- a/public/popup.html
+++ b/public/popup.html
@@ -76,7 +76,7 @@
             <p>Verify content authenticity using <a href="https://c2pa.org/" target="_blank">C2PA
                     Content Credentials</a>. Detect AI-generated and edited media directly in your browser.</p>
 
-            <p>Visit <a href="https://verifieddit.com" target="_blank">verifieddit.com</a>
+            <p>Visit <a href="https://www.verifieddit.com" target="_blank">www.verifieddit.com</a>
                 for more information.</p>
 
             <hr>

--- a/scripts/generate-build-info.js
+++ b/scripts/generate-build-info.js
@@ -28,7 +28,7 @@ const exactTag    = git('describe --tags --exact-match', '');
 const buildDate   = new Date().toISOString();
 const buildHost   = (process.env.RUNNER_NAME || process.env.HOSTNAME || os.hostname() || 'unknown').replace(/[\r\n]/g, '');
 
-const repoUrl = 'https://github.com/Sanmarcsoft/youseddit-extension-validator';
+const repoUrl = 'https://github.com/Sanmarcsoft/verifieddit-extension';
 
 const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 

--- a/src/manifest.firefox.v3.json
+++ b/src/manifest.firefox.v3.json
@@ -1,6 +1,8 @@
 {
     "manifest_version": 3,
-    "name": "verifieddit",
+    "name": "Verifieddit - C2PA Content Credential Verifier",
+    "short_name": "Verifieddit",
+    "description": "Verify content authenticity using C2PA Content Credentials. Detect AI-generated and edited media directly in your browser.",
     "version": "1.0.0",
     "permissions": [
         "storage",

--- a/test/fixtures/README.md
+++ b/test/fixtures/README.md
@@ -1,7 +1,7 @@
 # Alpha-Gold Fixtures — Issue #39
 
 Fixtures supporting the Alpha-Gold MVP demo gate for the verifieddit extension
-(tracked in GitHub issue `Sanmarcsoft/youseddit-extension-validator#39`).
+(tracked in GitHub issue `Sanmarcsoft/verifieddit-extension#39`).
 
 All images in `./` and `./demo-corpus/` are signed (or deliberately not signed)
 on branch `feature/39-rc2-fixtures` using the regenerated local test PKI under

--- a/test/fixtures/demo-corpus/manifest.json
+++ b/test/fixtures/demo-corpus/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "name": "verifieddit Alpha-Gold demo corpus",
-  "issue": "Sanmarcsoft/youseddit-extension-validator#39",
+  "issue": "Sanmarcsoft/verifieddit-extension#39",
   "branch": "feature/39-rc2-fixtures",
   "generated_at": "2026-04-21",
   "signer_fingerprint_sha256": "a1d71e68d2a48f08045700119c14a81d62d043a06ccc15249abc59f90b262e59",

--- a/test/test-trust-list.json
+++ b/test/test-trust-list.json
@@ -1,7 +1,7 @@
 {
   "name": "C2PA Official Trust List",
   "download_url": "",
-  "description": "Official C2PA trust anchors from c2pa-org/conformance-public \u2014 synced with verifieddit.com",
+  "description": "Official C2PA trust anchors from c2pa-org/conformance-public \u2014 synced with www.verifieddit.com",
   "website": "https://github.com/c2pa-org/conformance-public",
   "last_updated": "2026-04-24T12:15:00Z",
   "entities": [
@@ -314,7 +314,7 @@
     {
       "name": "Verifieddit Test Signer (local dev fixtures, Apr 2026)",
       "display_name": "Verifieddit Test Signer",
-      "contact": "https://verifieddit.com",
+      "contact": "https://www.verifieddit.com",
       "isCA": false,
       "jwks": {
         "keys": [


### PR DESCRIPTION
## What this PR does

Final rebrand cleanup ahead of Chrome Web Store, Firefox AMO, and Microsoft Edge Add-ons submission. Companion commit to the GitHub repo rename (`Sanmarcsoft/youseddit-extension-validator` → `Sanmarcsoft/verifieddit-extension`) executed today (2026-05-17).

## Changes (9 files)

### CWS listing (`CHROME_WEB_STORE_LISTING.md`)
- New **Developer / Publisher Identity** section names **SanMarcSoft LLC** as the Publisher displayed on the listing.
- Source repo URL updated to `verifieddit-extension`.
- All five marketing and privacy URLs prefixed with `www.` for consistency.

### Repo URL sweep (`Sanmarcsoft/youseddit-extension-validator` → `Sanmarcsoft/verifieddit-extension`)
- `ROADMAP.md` title and all 12 GitHub issue / PR / milestone links.
- `scripts/generate-build-info.js` `repoUrl` constant.
- `test/fixtures/README.md` issue reference.
- `test/fixtures/demo-corpus/manifest.json` `issue` field.

### Marketing-domain sweep (bare `https://verifieddit.com` → `https://www.verifieddit.com`)
- `public/popup.html` visible 'Visit verifieddit.com' link (user-facing in extension popup).
- `test/test-trust-list.json` description plus the Verifieddit Test Signer `contact` field.

### Other
- `src/manifest.firefox.v3.json` normalized (`name`, `short_name`, `description` match Chrome).
- `RENAME_PLAN_verifieddit.md` marked **COMPLETE** at top; original plan text preserved as history.

## Deliberately NOT changed

| Path | Reason |
|---|---|
| `infra/Pulumi.yaml`, `infra/index.ts`, `infra/package.json` | Pulumi resource names. Renaming would trigger Scaleway bucket destroy/recreate. Internal identifiers, not public-facing. |
| `src/build-info.ts` | Gitignored, regenerated on next build by `scripts/generate-build-info.js` (whose `repoUrl` constant is updated here). |
| `RENAME_PLAN_verifieddit.md` line 51 | Original plan text retained as historical record. File marked COMPLETE at top. |
| `src/manifest.firefox.v3.json browser_specific_settings.gecko.id` | Separate decision pending. Follow-up PR. |

## Verification

```
grep -rIn 'youseddit-extension-validator' --include='*.{md,ts,js,json,yaml,yml}'
  → only infra/* (intentional) and the historical RENAME_PLAN note.

grep -rIn 'https://verifieddit.com' (bare, no www)
  → zero in tracked source.

curl -sI https://github.com/Sanmarcsoft/youseddit-extension-validator
  → 301 redirect to verifieddit-extension.

curl -sI https://github.com/Sanmarcsoft/verifieddit-extension
  → 200 OK.
```

## Linked issues

Closes #95.
Addresses #34 (CWS listing alignment).
Part of #36 epic (Verifieddit v1.0.0 CWS submission).