### PR TITLE
feat(#97): add browser_specific_settings.gecko.id for Firefox AMO submission

### DIFF
--- a/src/manifest.firefox.v3.json
+++ b/src/manifest.firefox.v3.json
@@ -2,6 +2,12 @@
     "manifest_version": 3,
     "name": "verifieddit",
     "version": "1.0.0",
+    "browser_specific_settings": {
+        "gecko": {
+            "id": "verifieddit@verifieddit.com",
+            "strict_min_version": "109.0"
+        }
+    },
     "permissions": [
         "storage",
         "scripting",


### PR DESCRIPTION
## Why

Firefox AMO requires `browser_specific_settings.gecko.id` in the manifest. Without it, the AMO submission package gets rejected.

## What

```json
"browser_specific_settings": {
  "gecko": {
    "id": "verifieddit@verifieddit.com",
    "strict_min_version": "109.0"
  }
}
```

## ID format justification

Email-format namespace is the modern AMO convention. Examples from popular extensions:
- uBlock Origin: `uBlock0@raymondhill.net`
- Dark Reader: `addon@darkreader.org`
- Tampermonkey: `firefox@tampermonkey.net`

The ID is opaque to Mozilla; just needs to be unique within AMO. **NOT a real mailbox.** Prefix `verifieddit@` keeps the namespace distinct from any real mailbox (e.g. `support@verifieddit.com`) that might later serve as the publicly-displayed contact email.

## strict_min_version: 109.0

Firefox 109 (January 2023) is the first release with stable Manifest V3 service-worker-equivalent support. Lower minimums would allow installation on Firefox versions that crash on MV3.

## Diff

One file, +6 lines, zero deletions. JSON validated with `jq`.

## Related

- Closes #97.
- Independent of #96 (rebrand sweep) — fields don't overlap, rebase will be clean.
- Part of #36 epic.