### PR TITLE
chore(#103): CWS listing privacy URL → canonical /privacy

### DIFF
--- a/CHROME_WEB_STORE_LISTING.md
+++ b/CHROME_WEB_STORE_LISTING.md
@@ -20,7 +20,7 @@ English
 - **Developer website:** https://www.verifieddit.com
 - **Marketing site:** https://www.verifieddit.com
 - **Support / contact email:** support@verifieddit.com (publicly displayed on the listing; mailbox confirmed-by-user 2026-05-17)
-- **Privacy policy URL:** https://www.verifieddit.com/docs/privacy/
+- **Privacy policy URL:** https://www.verifieddit.com/privacy
 - **Source repository:** https://github.com/Sanmarcsoft/verifieddit-extension
 
 Listing the LLC as Publisher on the Chrome Web Store requires either (a) submitting from a Google Workspace account on a SanMarcSoft-owned domain, or (b) setting "SanMarcSoft LLC" as the verified Publisher name on an existing CWS developer account. CWS will display the registered publisher name to end users — verify spelling before submit.
@@ -61,7 +61,7 @@ Built on Microsoft's C2PA Extension Validator. View the source code at https://g
 Learn more at https://www.verifieddit.com
 
 ## Privacy Policy URL
-https://www.verifieddit.com/docs/privacy/
+https://www.verifieddit.com/privacy
 
 ## Permission Justifications
 


### PR DESCRIPTION
## Why

Final pre-submission tightening per M directive ("acceptance on first submission and a fully functioning chrome extension"). The CWS listing was advertising `https://www.verifieddit.com/docs/privacy/` which 301-redirects to `/privacy` via a deliberate Cloudflare edge rule that bypasses the `/docs/*` Access gate (per Sanmarcsoft/verifieddit-www#398 — closed today). The redirect is correct architecture; the listing pointing at the redirect source is sloppy.

## What

Two replacements in `CHROME_WEB_STORE_LISTING.md`:
- L23: `Developer Identity` block / Privacy policy URL
- L64: `Privacy Policy URL` standalone block

Both `https://www.verifieddit.com/docs/privacy/` → `https://www.verifieddit.com/privacy`.

## Verification

```bash
curl -sIL https://www.verifieddit.com/privacy
# HTTP/2 200 (no Access redirect, no /docs/ hop)
```

## Stats

1 file changed, 2 insertions(+), 2 deletions(-).

## Related

- Closes #103.
- Companion to Sanmarcsoft/verifieddit-www#398 (already merged on the web repo).
- Part of #36 epic.